### PR TITLE
Suggestion to use consistent information about running docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Documentation search is powered by [Algolia's DocSearch](https://community.algol
 1. Run through the [tooling setup](https://github.com/twbs/bootstrap/blob/v4-dev/docs/4.0/getting-started/build-tools.md#tooling-setup) to install Jekyll (the site builder) and other Ruby dependencies with `bundle install`.
 2. Run `npm install` to install Node.js dependencies.
 3. Run `npm run test` (or a specific NPM script) to rebuild distributed CSS and JavaScript files, as well as our docs assets.
-4. From the root `/bootstrap` directory, run `bundle exec jekyll serve` in the command line.
+4. From the root `/bootstrap` directory, run `npm run docs-serve` in the command line.
 5. Open <http://localhost:9001> in your browser, and voilà.
 
 Learn more about using Jekyll by reading its [documentation](https://jekyllrb.com/docs/home/).


### PR DESCRIPTION
Idea is about to leave Ruby/Bundler commands in tooling section/readme/space, and on main readme use npm scripts syntax.